### PR TITLE
Extend preview.ts to make it more generic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,27 +168,13 @@ Please see the [Nodemailer](https://nodemailer.com) documentation for more infor
 
 For most people, the built-in renderer is sufficient. However, if you need to use a custom transpiler (for example, to add a preprocessor), the following steps will help you:
 
-1. **Write a Node.js script for your renderer.** Your script should read a JSON object from STDIN. The JSON object will contain two properties: `directory` and `content`. Your script should handle transpiling MJML to HTML, along with any other preprocessing steps you require, and output a JSON object with properties `html` and `errors` to STDOUT.
+1. **Write a Node.js script for your renderer.** Your script should read a JSON object from STDIN. Your script should handle transpiling MJML to HTML, along with any other preprocessing steps you require, and output a JSON object.
 
-    The shapes of the STDIN/STDOUT objects are:
+    The schema of the STDIN/STDOUT objects are:
 
-    - STDIN (sent to your Node script by this extension):
+    - STDIN (sent to your Node script by `vscode-mjml`): see `./json-schema/custom-renderer/stdin-schema.json`
 
-    ```json
-    {
-        "directory": "name of the parent directory of the file being previewed",
-        "content": "MJML content of the file being previewed"
-    }
-    ```
-
-    - STDOUT (output from your Node script):
-
-    ```json
-    {
-        "html": "transpiled HTML to be rendered as your file's preview",
-        "errors": "an array of any errors that occur while processing the file's contents (formatted as strings). If this array is not empty, these errors will be rendered instead"
-    }
-    ```
+    - STDOUT (output from your Node script): see `./json-schema/custom-renderer/stdout-schema.json`
 
 2. **Update your workspace's `settings.json`**.
 
@@ -205,6 +191,10 @@ For most people, the built-in renderer is sufficient. However, if you need to us
     }
     ```
 -   Save and close this file. You don't need to restart VS Code for this to take effect.
+
+### Examples
+
+A sample custom renderer is provided in `./examples/custom-renderer.js`.
 
 ## Change Log
 

--- a/examples/custom-renderer.js
+++ b/examples/custom-renderer.js
@@ -1,0 +1,22 @@
+const {readFileSync} = require("fs");
+const mjml = require('mjml');
+
+// Read input from process.stdin
+const stdin = readFileSync(0, "utf-8");
+
+// Parse input
+const { directory, content, filePath, options } = JSON.parse(stdin);
+
+function processMJML(filePath, content) {
+    let html, errors = [];
+
+    // you can do some preprocessing, e.g read frontmatter, inject custom styles or compile with handlebars.js
+    // I'm just going to transpile `content` directly (essentially, doing what vscode-mjml already does)
+    html = mjml(content).html;
+
+    return {html, errors};
+}
+
+process.stdout.write(
+    JSON.stringify(processMJML(filePath, content))
+);

--- a/json-schema/custom-renderer/stdin-schema.json
+++ b/json-schema/custom-renderer/stdin-schema.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "STDIN JSON payload",
+    "description": "This payload is written to the STDIN of the renderer script and needs to be parsed by it",
+    "type": "object",
+    "properties":{
+        "directory": {
+            "description": "parent directory of file being previewed",
+            "type": "string"
+        },
+        "filePath": {
+            "description": "absolute path of file being previewed",
+            "type": "string"
+        },
+        "content": {
+            "description": "MJML contents of file being previewed. It is recommended to use this instead of reading from the file because modifications to the file might not have been saved at the time it is previewed.",
+            "type": "string"
+        },
+        "options": {
+            "description": "any existing configuration options are passed here",
+            "type": "object",
+            "properties": {
+                "mjmlConfigPath": {
+                    "description": "path to MJML configuration file/directory",
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/json-schema/custom-renderer/stdout-schema.json
+++ b/json-schema/custom-renderer/stdout-schema.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "STDOUT JSON payload",
+    "description": "This payload needs to be marshalled and written to STDOUT by the renderer script",
+    "type": "object",
+    "properties":{
+        "html": {
+            "description": "HTML code to be rendered.",
+            "type": "string"
+        },
+        "errors": {
+            "description": "Any errors that in transpiling/processing the MJML sent to the renderer script.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "line": {
+                        "description": "Line number where error occurred",
+                        "type": "number"
+                    },
+                    "message": {
+                        "description": "The error object, but stringified",
+                        "type": "string"
+                    },
+                    "formattedMessage": {
+                        "description": "Actual message renderer script wants vscode-mjml to render for this error",
+                        "type": "string"
+                    },
+                    "tagName": {
+                        "description": "Name of the tag this error occurred at",
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,10 +1,9 @@
-import { existsSync, readFileSync, statSync } from 'fs'
-import { basename, dirname, join as joinPath, parse as parsePath } from 'path'
-import { TextDocument, TextEditor, window, workspace } from 'vscode'
-
-import { html as jsBeautify } from 'js-beautify'
-import { getExtension, getType as getMimeType } from 'mime'
-import * as mjml2html from 'mjml'
+import { existsSync, readFileSync, statSync } from 'fs';
+import { html as jsBeautify } from 'js-beautify';
+import { getExtension, getType as getMimeType } from 'mime';
+import * as mjml2html from 'mjml';
+import { basename, dirname, join as joinPath, parse as parsePath } from 'path';
+import { TextDocument, TextEditor, window, workspace } from 'vscode';
 
 export function renderMJML(
     cb: (content: string) => any,
@@ -107,7 +106,7 @@ export function beautifyHTML(mjml: string): string | undefined {
 
         return beautified
     } catch (error) {
-        window.showErrorMessage(error)
+        window.showErrorMessage(error as string)
 
         return
     }
@@ -121,7 +120,7 @@ export function getPath(): string {
     return ''
 }
 
-function getCWD(mjmlPath?: string): string {
+export function getCWD(mjmlPath?: string): string {
     if (workspace.rootPath) {
         return workspace.rootPath
     }


### PR DESCRIPTION
- Pass `directory`, `filePath`, `content` and `options` to custom renderer script.
- Allow vscode-mjml to render errors returned by custom renderer.
- Add JSON schema files for STDIN and STDOUT objects.
- Document new changes in README.
- Add `./examples/custom-renderer.js`.